### PR TITLE
Don't use the 'custom' feature of getrandom

### DIFF
--- a/mls-rs-crypto-nss/Cargo.toml
+++ b/mls-rs-crypto-nss/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 
 # Random
-getrandom = { version = "0.2", default-features = false, features = ["custom"] }
+getrandom = { version = "0.2", default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 
 maybe-async = "0.2.10"


### PR DESCRIPTION
This crate does not use the `register_custom_getrandom!()` macro that is enabled by this feature. It was removed in `getrandom 0.3`, so using this feature may (incorrectly) make eventual migration more difficult.