### PR TITLE
Bumping itertools version to 0.14.x

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -60,7 +60,7 @@ mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = fa
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 mls-rs-codec = { version = "0.6", path = "../mls-rs-codec", default-features = false}
 thiserror = { version = "1.0.40", optional = true }
-itertools = { version = "0.10.5", default-features = false, features = ["use_alloc"]}
+itertools = { version = "0.14", default-features = false, features = ["use_alloc"]}
 cfg-if = "1"
 debug_tree = { version = "0.4.0", optional = true }
 # spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex"] }


### PR DESCRIPTION
This makes it match the version in moz-central.

### Issues:

Resolves https://bugzilla.mozilla.org/show_bug.cgi?id=1988846

### Testing:

`cargo build` and `cargo test` both passed.  Is there anything else I should test?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
